### PR TITLE
Trigger tag workflows from CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,11 +2,10 @@
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -48,5 +47,5 @@ jobs:
           gradle-version: 6.3
           arguments: reckonTagPush -Preckon.stage=rc -x test # tests require kubectl proxy to work
         env:
-          GRGIT_USER: miguelaferreira
-          GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+          GRGIT_USER: ${GITHUB_ACTOR}
+          GRGIT_PASS: ${{ secrets.REPO_CI_TOKEN }}

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -3,7 +3,7 @@
 name: TAG
 
 on:
-  create:
+  push:
     tags:
       - '**'  # all tags
 
@@ -22,4 +22,4 @@ jobs:
         env:
           DOCKER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: .github/scripts/build-containers.sh "${GITHUB_REF/refs\/tags\//}"
+        run: .github/scripts/build-containers.sh "${GITHUB_REF#refs/tags/}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/miguelaferreira/k8s-terraform-module-controller/workflows/CI/badge.svg)
+
 # k8s-terraform-controller
 
 K8s controller to execute terraform modules.


### PR DESCRIPTION
This PR changes the github actions workflow config to trigger the TAG workflow from the CI workflow. This wasn't the case before because we used the GITHUB_TOKEN to push the created tags, and that won't trigger a new workflow. See https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676